### PR TITLE
Support in-memory operations for minidump processing

### DIFF
--- a/cpp/memstream.h
+++ b/cpp/memstream.h
@@ -1,0 +1,49 @@
+#ifndef SENTRY_MEMSTREAM_H
+#define SENTRY_MEMSTREAM_H
+
+#include <istream>
+#include <streambuf>
+
+/// Stream buffer for in-memory buffers
+///
+/// Allows to stream from and to a raw buffer in memory that also implements
+/// `seekg` and `tellp`. Since the buffer is const, this buffer can only be used
+/// to construct an input stream.
+///
+/// See `imemstream` for an input stream implementation. Use `ostringstream` for
+/// in-memory output operations.
+struct membuf : std::streambuf {
+  membuf(const char *base, size_t size) {
+    char *p(const_cast<char *>(base));
+    this->setg(p, p, p + size);
+  }
+
+ protected:
+  pos_type seekoff(off_type off,
+                   std::ios_base::seekdir dir,
+                   std::ios_base::openmode which = std::ios_base::in) override {
+    if (dir == std::ios_base::cur)
+      gbump(off);
+    else if (dir == std::ios_base::end)
+      setg(eback(), egptr() + off, egptr());
+    else if (dir == std::ios_base::beg)
+      setg(eback(), eback() + off, egptr());
+    return gptr() - eback();
+  }
+
+  pos_type seekpos(pos_type sp, std::ios_base::openmode which) override {
+    return seekoff(sp - pos_type(off_type(0)), std::ios_base::beg, which);
+  }
+};
+
+/// In-memory input stream from const raw buffers
+///
+/// Behaves just like an `istringstream` except that it does not clone the
+/// underlying buffer. Use `ostringstream` as in-memory output stream.
+struct imemstream : virtual membuf, std::istream {
+  imemstream(char const *base, size_t size)
+      : membuf(base, size), std::istream(static_cast<std::streambuf *>(this)) {
+  }
+};
+
+#endif

--- a/cpp/processor.cpp
+++ b/cpp/processor.cpp
@@ -229,25 +229,17 @@ char *code_module_debug_identifier(const code_module_t *module) {
   return string_from(code_module_t::cast(module)->debug_identifier());
 }
 
-resolver_t *resolver_new(const char *symbol_file) {
-  std::ifstream in(symbol_file);
-  if (!in.good()) {
+resolver_t *resolver_new(const char *symbol_buffer, size_t buffer_size) {
+  if (symbol_buffer == nullptr || buffer_size == 0) {
     return nullptr;
   }
-
-  in.seekg(0, std::ios::end);
-  std::streampos length = in.tellg();
-  std::vector<char> buffer(length);
-
-  in.seekg(0, std::ios::beg);
-  in.read(&buffer[0], length);
 
   auto *module = factory.CreateModule("");
   if (module == nullptr) {
     return nullptr;
   }
 
-  module->LoadMapFromMemory(&buffer[0], length);
+  module->LoadMapFromMemory(const_cast<char *>(symbol_buffer), buffer_size);
   return resolver_t::cast(module);
 }
 

--- a/cpp/processor.h
+++ b/cpp/processor.h
@@ -172,11 +172,10 @@ char *code_module_debug_file(const code_module_t *module);
 char *code_module_debug_identifier(const code_module_t *module);
 
 /// Creates a new source line resolver instance and returns an owning pointer
-/// to it. Symbols are loaded from a Breakpad symbol file in the file system.
-/// The file name is given as a weak pointer in the symbol_file parameter.
+/// to it. Symbols are loaded from a buffer containing symbols in ASCII format.
 ///
 /// Release memory of this resolver with the resolver_delete function.
-resolver_t *resolver_new(const char *symbol_file);
+resolver_t *resolver_new(const char *symbol_buffer, size_t buffer_size);
 
 /// Releases memory of a resolver object. Assumes ownership of the pointer.
 void resolver_delete(resolver_t *resolver);

--- a/cpp/processor.h
+++ b/cpp/processor.h
@@ -46,17 +46,18 @@ struct symbol_entry_t {
   const char *symbol_data;
 };
 
-/// Reads a minidump from the file system into memory and processes it. Returns
-/// an owning pointer to a process_state_t struct that contains loaded code
-/// modules and call stacks of all threads of the process during the crash.
+/// Reads a minidump from a memory buffer and processes it. Returns an owning
+/// pointer to a process_state_t struct that contains loaded code modules and
+/// call stacks of all threads of the process during the crash.
 ///
-/// Processing the minidump can fail if the file is corrupted or does not exit.
-/// The function will return NULL and an error code in result_out.
+/// Processing the minidump can fail if the buffer is corrupted or does not
+/// exit. The function will return NULL and an error code in result_out.
 ///
 /// Release memory of the process state with process_state_delete.
-process_state_t *process_minidump(const char *file_path,
-                                  size_t symbol_count,
+process_state_t *process_minidump(const char *buffer,
+                                  size_t buffer_size,
                                   symbol_entry_t *symbols,
+                                  size_t symbol_count,
                                   int *result_out);
 
 /// Releases memory of a process state struct. Assumes ownership of the pointer.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,7 @@ use process_state::ProcessResult;
 
 error_chain! {
     foreign_links {
-        Io(::std::io::Error);
+        IoError(::std::io::Error);
     }
 
     errors {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,10 @@
 use process_state::ProcessResult;
 
 error_chain! {
+    foreign_links {
+        Io(::std::io::Error);
+    }
+
     errors {
         /// An error raised when processing a dump by `ProcessState`.
         ProcessError(result: ProcessResult) {

--- a/src/process_state.rs
+++ b/src/process_state.rs
@@ -2,15 +2,13 @@ use std::{fmt, mem, ptr, slice};
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::ffi::CString;
-use std::io::prelude::*;
-use std::fs::File;
 use std::os::raw::{c_char, c_void};
 use std::path::Path;
 
 use call_stack::CallStack;
 use code_module::{CodeModule, CodeModuleId};
 use errors::ErrorKind::ProcessError;
-use errors::{Error, Result};
+use errors::Result;
 use utils;
 
 /// Result of processing a Minidump or Microdump file.

--- a/src/process_state.rs
+++ b/src/process_state.rs
@@ -109,7 +109,7 @@ impl ProcessState {
     /// process. The parameter `frame_infos` expects a map of Breakpad symbols
     /// containing STACK CFI and STACK WIN records to allow stackwalking with
     /// omitted frame pointers.
-    pub fn from_minidump_path<P: AsRef<Path>>(
+    pub fn from_minidump_file<P: AsRef<Path>>(
         file_path: P,
         frame_infos: Option<&FrameInfoMap>,
     ) -> Result<ProcessState> {
@@ -124,7 +124,7 @@ impl ProcessState {
     /// containing STACK CFI and STACK WIN records to allow stackwalking with
     /// omitted frame pointers.
     pub fn from_minidump_buffer(
-        dump: &[u8],
+        buffer: &[u8],
         frame_infos: Option<&FrameInfoMap>,
     ) -> Result<ProcessState> {
         let cfi_count = frame_infos.map_or(0, |s| s.len());
@@ -151,8 +151,8 @@ impl ProcessState {
 
         let internal = unsafe {
             process_minidump(
-                dump.as_ptr() as *const c_char,
-                dump.len(),
+                buffer.as_ptr() as *const c_char,
+                buffer.len(),
                 cfi_entries.as_ptr(),
                 cfi_count,
                 &mut result,

--- a/src/process_state.rs
+++ b/src/process_state.rs
@@ -2,13 +2,15 @@ use std::{fmt, mem, ptr, slice};
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::ffi::CString;
+use std::io::prelude::*;
+use std::fs::File;
 use std::os::raw::{c_char, c_void};
 use std::path::Path;
 
 use call_stack::CallStack;
 use code_module::{CodeModule, CodeModuleId};
 use errors::ErrorKind::ProcessError;
-use errors::Result;
+use errors::{Error, Result};
 use utils;
 
 /// Result of processing a Minidump or Microdump file.
@@ -72,9 +74,10 @@ struct SymbolEntry {
 
 extern "C" {
     fn process_minidump(
-        file_path: *const c_char,
-        symbol_count: usize,
+        buffer: *const c_char,
+        buffer_size: usize,
         symbols: *const SymbolEntry,
+        symbol_count: usize,
         result: *mut ProcessResult,
     ) -> *mut Internal;
     fn process_state_delete(state: *mut Internal);
@@ -108,11 +111,24 @@ impl ProcessState {
     /// process. The parameter `frame_infos` expects a map of Breakpad symbols
     /// containing STACK CFI and STACK WIN records to allow stackwalking with
     /// omitted frame pointers.
-    pub fn from_minidump<P: AsRef<Path>>(
+    pub fn from_minidump_path<P: AsRef<Path>>(
         file_path: P,
         frame_infos: Option<&FrameInfoMap>,
     ) -> Result<ProcessState> {
-        let cstr = utils::path_to_str(file_path);
+        let buffer = utils::read_buffer(file_path)?;
+        Self::from_minidump_buffer(buffer.as_slice(), frame_infos)
+    }
+
+    /// Processes a minidump supplied via raw binary data
+    ///
+    /// Returns a `ProcessState` that contains information about the crashed
+    /// process. The parameter `frame_infos` expects a map of Breakpad symbols
+    /// containing STACK CFI and STACK WIN records to allow stackwalking with
+    /// omitted frame pointers.
+    pub fn from_minidump_buffer(
+        dump: &[u8],
+        frame_infos: Option<&FrameInfoMap>,
+    ) -> Result<ProcessState> {
         let cfi_count = frame_infos.map_or(0, |s| s.len());
         let mut result: ProcessResult = ProcessResult::Ok;
 
@@ -136,7 +152,13 @@ impl ProcessState {
             .collect();
 
         let internal = unsafe {
-            process_minidump(cstr.as_ptr(), cfi_count, cfi_entries.as_ptr(), &mut result)
+            process_minidump(
+                dump.as_ptr() as *const c_char,
+                dump.len(),
+                cfi_entries.as_ptr(),
+                cfi_count,
+                &mut result,
+            )
         };
 
         if result == ProcessResult::Ok && !internal.is_null() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,10 @@
 use std::ffi::{CStr, CString};
+use std::fs::File;
+use std::io::prelude::*;
 use std::os::raw::c_char;
 use std::path::Path;
+
+use errors::Result;
 
 extern "C" {
     fn string_delete(string: *mut c_char);
@@ -40,4 +44,12 @@ pub fn path_to_bytes<P: AsRef<Path> + ?Sized>(path: &P) -> &[u8] {
 pub fn path_to_str<P: AsRef<Path>>(path: P) -> CString {
     let bytes = path_to_bytes(path.as_ref());
     CString::new(bytes).unwrap()
+}
+
+/// Reads an entire file into a memory buffer
+pub fn read_buffer<P: AsRef<Path>>(path: P) -> Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    let mut file = File::open(path)?;
+    file.read_to_end(&mut buffer)?;
+    Ok(buffer)
 }

--- a/tests/minidump.rs
+++ b/tests/minidump.rs
@@ -12,7 +12,7 @@ use common::{assert_snapshot, fixture_path, load_fixture};
 
 #[test]
 fn process_minidump_from_path() {
-    let state = ProcessState::from_minidump_path(fixture_path("crash_macos.dmp"), None)
+    let state = ProcessState::from_minidump_file(fixture_path("crash_macos.dmp"), None)
         .expect("Could not process minidump");
 
     assert_snapshot("process_state.txt", &state);
@@ -33,7 +33,7 @@ fn process_minidump_from_buffer() {
 
 #[test]
 fn obtain_referenced_modules() {
-    let state = ProcessState::from_minidump_path(fixture_path("crash_macos.dmp"), None)
+    let state = ProcessState::from_minidump_file(fixture_path("crash_macos.dmp"), None)
         .expect("Could not process minidump");
 
     let modules: BTreeSet<_> = state.referenced_modules().iter().cloned().collect();
@@ -49,7 +49,7 @@ fn get_minidump_process_state_cfi() {
     let mut symbols = FrameInfoMap::new();
     symbols.insert(module_id, module_cfi.as_bytes());
 
-    let state = ProcessState::from_minidump_path(fixture_path("crash_macos.dmp"), Some(&symbols))
+    let state = ProcessState::from_minidump_file(fixture_path("crash_macos.dmp"), Some(&symbols))
         .expect("Could not process minidump");
 
     assert_snapshot("process_state_cfi.txt", &state);

--- a/tests/minidump.rs
+++ b/tests/minidump.rs
@@ -4,13 +4,28 @@ extern crate difference;
 mod common;
 
 use std::collections::BTreeSet;
+use std::fs::File;
+use std::io::prelude::*;
 
 use breakpad::{CodeModuleId, FrameInfoMap, ProcessState};
 use common::{assert_snapshot, fixture_path, load_fixture};
 
 #[test]
-fn get_minidump_process_state() {
-    let state = ProcessState::from_minidump(fixture_path("crash_macos.dmp"), None)
+fn process_minidump_from_path() {
+    let state = ProcessState::from_minidump_path(fixture_path("crash_macos.dmp"), None)
+        .expect("Could not process minidump");
+
+    assert_snapshot("process_state.txt", &state);
+}
+
+#[test]
+fn process_minidump_from_buffer() {
+    let mut buffer = Vec::new();
+    let mut file = File::open(fixture_path("crash_macos.dmp")).expect("Could not open minidump");
+    file.read_to_end(&mut buffer)
+        .expect("Could not read minidump");
+
+    let state = ProcessState::from_minidump_buffer(buffer.as_slice(), None)
         .expect("Could not process minidump");
 
     assert_snapshot("process_state.txt", &state);
@@ -18,7 +33,7 @@ fn get_minidump_process_state() {
 
 #[test]
 fn obtain_referenced_modules() {
-    let state = ProcessState::from_minidump(fixture_path("crash_macos.dmp"), None)
+    let state = ProcessState::from_minidump_path(fixture_path("crash_macos.dmp"), None)
         .expect("Could not process minidump");
 
     let modules: BTreeSet<_> = state.referenced_modules().iter().cloned().collect();
@@ -34,7 +49,7 @@ fn get_minidump_process_state_cfi() {
     let mut symbols = FrameInfoMap::new();
     symbols.insert(module_id, module_cfi.as_bytes());
 
-    let state = ProcessState::from_minidump(fixture_path("crash_macos.dmp"), Some(&symbols))
+    let state = ProcessState::from_minidump_path(fixture_path("crash_macos.dmp"), Some(&symbols))
         .expect("Could not process minidump");
 
     assert_snapshot("process_state_cfi.txt", &state);

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -8,7 +8,7 @@ use common::{assert_snapshot, fixture_path};
 
 #[test]
 fn resolve_stack_frame() {
-    let state = ProcessState::from_minidump_path(fixture_path("crash_macos.dmp"), None).unwrap();
+    let state = ProcessState::from_minidump_file(fixture_path("crash_macos.dmp"), None).unwrap();
     let thread = state.threads().first().unwrap();
     let frame = thread.frames()[0];
 

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -3,8 +3,37 @@ extern crate difference;
 
 mod common;
 
+use std::fs::File;
+use std::io::prelude::*;
+
 use breakpad::{ProcessState, Resolver};
 use common::{assert_snapshot, fixture_path};
+
+#[test]
+fn create_from_file() {
+    let resolver =
+        Resolver::from_file(fixture_path("crash_macos_func.sym")).expect("Could not load symbols");
+    assert!(!resolver.corrupt());
+}
+
+#[test]
+fn create_from_buffer() {
+    let mut buffer = Vec::new();
+    let mut file =
+        File::open(fixture_path("crash_macos_func.sym")).expect("Could not open symbols");
+    file.read_to_end(&mut buffer)
+        .expect("Could not read symbols");
+
+    let resolver = Resolver::from_buffer(buffer.as_slice()).expect("Could not load symbols");
+    assert!(!resolver.corrupt());
+}
+
+#[test]
+fn create_corrupt_resolver() {
+    let resolver =
+        Resolver::from_file(fixture_path("Corrupt.sym")).expect("Could not load symbols");
+    assert!(resolver.corrupt());
+}
 
 #[test]
 fn resolve_stack_frame() {
@@ -13,14 +42,8 @@ fn resolve_stack_frame() {
     let frame = thread.frames()[0];
 
     let resolver =
-        Resolver::new(fixture_path("crash_macos_func.sym")).expect("Could not load symbols");
+        Resolver::from_file(fixture_path("crash_macos_func.sym")).expect("Could not load symbols");
 
     let resolved_frame = resolver.resolve_frame(&frame);
     assert_snapshot("resolved_frame.txt", &resolved_frame);
-}
-
-#[test]
-fn create_corrupt_resolver() {
-    let resolver = Resolver::new(fixture_path("Corrupt.sym")).expect("Could not load symbols");
-    assert!(resolver.corrupt());
 }

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -8,7 +8,7 @@ use common::{assert_snapshot, fixture_path};
 
 #[test]
 fn resolve_stack_frame() {
-    let state = ProcessState::from_minidump(fixture_path("crash_macos.dmp"), None).unwrap();
+    let state = ProcessState::from_minidump_path(fixture_path("crash_macos.dmp"), None).unwrap();
     let thread = state.threads().first().unwrap();
     let frame = thread.frames()[0];
 


### PR DESCRIPTION
This PR introduces the option to pass a minidump file in memory to the
processor. Since `google_breakpad::Minidump` only allows to read from
files or `istream`s, we have to provide our own in-memory `istream`
implementation.

The C++ interface is changed to support only in-memory operations. For
file-based operations, we read the entire file in Rust into a buffer
first and pass it down via FFI.