### PR TITLE
Load correct stack memory if thread record is wrong

### DIFF
--- a/src/google_breakpad/processor/stackwalker.h
+++ b/src/google_breakpad/processor/stackwalker.h
@@ -49,6 +49,7 @@
 #include "google_breakpad/common/breakpad_types.h"
 #include "google_breakpad/processor/code_modules.h"
 #include "google_breakpad/processor/memory_region.h"
+#include "google_breakpad/processor/minidump.h"
 #include "google_breakpad/processor/stack_frame_symbolizer.h"
 
 namespace google_breakpad {
@@ -88,6 +89,7 @@ class Stackwalker {
      const SystemInfo* system_info,
      DumpContext* context,
      MemoryRegion* memory,
+     MinidumpMemoryList* memory_list,
      const CodeModules* modules,
      const CodeModules* unloaded_modules,
      StackFrameSymbolizer* resolver_helper);

--- a/src/processor/microdump_processor.cc
+++ b/src/processor/microdump_processor.cc
@@ -66,6 +66,7 @@ ProcessResult MicrodumpProcessor::Process(Microdump *microdump,
                             &process_state->system_info_,
                             microdump->GetContext(),
                             microdump->GetMemory(),
+                            /* memory_list */ NULL,
                             process_state->modules_,
                             /* unloaded_modules= */ NULL,
                             frame_symbolizer_));

--- a/src/processor/minidump_processor.cc
+++ b/src/processor/minidump_processor.cc
@@ -267,6 +267,7 @@ ProcessResult MinidumpProcessor::Process(
         Stackwalker::StackwalkerForCPU(process_state->system_info(),
                                        context,
                                        thread_memory,
+                                       memory_list,
                                        process_state->modules_,
                                        process_state->unloaded_modules_,
                                        frame_symbolizer_));


### PR DESCRIPTION
Some minidumps contain invalid thread memory descriptors pointing to memory regions other than the ones referred to by the RSP. This is the case in UE4, for example. This causes the stackwalker to terminate early as it cannot load the actual stack memory. 

Other Minidump processors such as WinDbg or the Visual Studio debugger can still process such minidumps correctly. They do not load the stack memory region based on the information obtained from the TEB and instead just follow the stack walker.

This patch adds the same behavior to the minidump processor. If the thread memory region does not cover the stack pointer, the region is replaced with the one covering it, if any.