### PR TITLE
fix: Conditionally swap the bytes when building debug_id

### DIFF
--- a/src/processor/minidump.cc
+++ b/src/processor/minidump.cc
@@ -2206,6 +2206,11 @@ string MinidumpModule::debug_identifier() const {
       memcpy(&guid, &cv_record_elf->build_id,
              std::min(cv_record_->size() - MDCVInfoELF_minsize,
                       sizeof(MDGUID)));
+      if (minidump_->swap()) {
+        Swap(&guid.data1);
+        Swap(&guid.data2);
+        Swap(&guid.data3);
+      }
       identifier = guid_and_age_to_debug_id(guid, 0);
     }
   }

--- a/src/processor/minidump.cc
+++ b/src/processor/minidump.cc
@@ -2207,6 +2207,15 @@ string MinidumpModule::debug_identifier() const {
              std::min(cv_record_->size() - MDCVInfoELF_minsize,
                       sizeof(MDGUID)));
       if (minidump_->swap()) {
+        // The debug_identifier needs to be computed for a big-endian
+        // MDGUID.  However if the host is LE reading into MDGUID
+        // implicitly reversed the order they are printed as
+        // guid_and_age_to_debug prints as hex numbers, not as bytes.
+        // This leads to 4 cases:
+        // BE dump on BE host: nothing swapped, printed in order
+        // BE dump on LE host: swap bytes & swapped back by MDGUID ints
+        // LE dump on BE host: swap bytes & printed in order
+        // LE dump on LE host: swapped by MDGUID ints
         Swap(&guid.data1);
         Swap(&guid.data2);
         Swap(&guid.data3);


### PR DESCRIPTION
When we are reading a minidump of different endianness we need to swap
the bytes of the integer fields of the GUID to build the correct
debug_id.  This because the debug_id is the hex representation of the
big-endian GUID.

When reading a little-endian minidump this does not swap, but since
the bytes are then implicitly swapped by reading them as little-endian
we end up converting their big-endian representation to hex.