### PR TITLE
fix: Uninstall iOS signal handler after one invocation

### DIFF
--- a/src/client/ios/exception_handler_no_mach.cc
+++ b/src/client/ios/exception_handler_no_mach.cc
@@ -194,6 +194,9 @@ void ExceptionHandler::SignalHandler(int sig, siginfo_t* info, void* uc) {
   if (gBreakpadAllocator)
     gBreakpadAllocator->Protect();
 #endif
+  // uninstall our own crash handler so that when the signal is re-raised, the
+  // default handler takes over.
+  gProtectedData.handler->UninstallHandlers();
 }
 
 bool ExceptionHandler::InstallHandlers() {


### PR DESCRIPTION
Priviously, the signal handler of iOS would not terminate the process or delegate to the original signal handler, which at least in the iOS simulator would lead to an infinite signal loop and start writing a huge amount of minidumps. By restoring the signal handlers to the original, only one minidump is written and the default signal handlers are invoked.