### PR TITLE
Fix for non-constant SIGSTKSZ

### DIFF
--- a/src/client/linux/handler/exception_handler.cc
+++ b/src/client/linux/handler/exception_handler.cc
@@ -138,7 +138,7 @@ void InstallAlternateStackLocked() {
   // SIGSTKSZ may be too small to prevent the signal handlers from overrunning
   // the alternative stack. Ensure that the size of the alternative stack is
   // large enough.
-  static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+  static const unsigned kSigStackSize = std::max((unsigned) 16384, (unsigned) SIGSTKSZ);
 
   // Only set an alternative stack if there isn't already one, or if the current
   // one is too small.


### PR DESCRIPTION
On glibc > 2.33, `SIGSTKSZ` might not be constant (in which case
it expands to a call to `sysconf` which returns a `long int`); see
http://sourceware-org.1504.n7.nabble.com/PATCH-sysconf-Add-SC-MINSIGSTKSZ-SC-SIGSTKSZ-BZ-20305-td650948.html

Cast the two arguments to `max` to `unsigned`, which is the type of the variable
we're storing the result in anyway, so that it works both with the old-style constant
`SIGSTKSZ` and the new configurable one.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/breakpad/11)
<!-- Reviewable:end -->
