### PR TITLE
fix: Skip FramePointerRecovery that yields an invalid IP

### DIFF
--- a/src/processor/stackwalker_amd64.cc
+++ b/src/processor/stackwalker_amd64.cc
@@ -186,7 +186,10 @@ StackFrameAMD64* StackwalkerAMD64::GetCallerByFramePointerRecovery(
 
     // If the recovered rip is not a canonical address it can't be
     // the return address, so rbp must not have been a frame pointer.
-    if (is_non_canonical(caller_rip)) {
+    // NOTE(swatinem): Frame pointer heuristics might be wrong and yield an IP
+    // which fails the check in `TerminateWalk`, so make sure we skip those early
+    // and resort to stack scanning instead.
+    if (is_non_canonical(caller_rip) || caller_rip < (1 << 12)) {
       return NULL;
     }
 


### PR DESCRIPTION
In some cases this yields a NULL IP, which is rejected later and the frame is discarded.
This resorts to scanning instead.

In local testing this solved a case where breakpad stopped immediately after the context, but resorting to scanning in that case can still lead to garbage down below.