### PR TITLE
fix: Try to use the Link Register on ARM64 for the first frame

### DIFF
--- a/src/processor/stackwalker_arm64.h
+++ b/src/processor/stackwalker_arm64.h
@@ -86,6 +86,10 @@ class StackwalkerARM64 : public Stackwalker {
   // Return NULL on failure.
   StackFrameARM64* GetCallerByFramePointer(const vector<StackFrame*>& frames);
 
+  // Use the link register if it seems to be a valid function address.
+  // The caller takes ownership of the returned frame. Return NULL on failure.
+  StackFrameARM64* GetCallerByLinkRegister(const vector<StackFrame*>& frames);
+
   // Scan the stack for plausible return addresses. The caller takes ownership
   // of the returned frame. Return NULL on failure.
   StackFrameARM64* GetCallerByStackScan(const vector<StackFrame*>& frames);


### PR DESCRIPTION
This adapts https://chromium.googlesource.com/breakpad/breakpad/+/f2b3ab5e0af48f59754a96f0dbe95e857ba1abbd%5E%21/ for the ARM64 stackwalker.