### PR TITLE
Cast SIGSTKSZ to int to fix build

### DIFF
--- a/src/client/linux/handler/exception_handler.cc
+++ b/src/client/linux/handler/exception_handler.cc
@@ -138,7 +138,7 @@ void InstallAlternateStackLocked() {
   // SIGSTKSZ may be too small to prevent the signal handlers from overrunning
   // the alternative stack. Ensure that the size of the alternative stack is
   // large enough.
-  static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+  static const unsigned kSigStackSize = std::max(16384, (int)SIGSTKSZ);
 
   // Only set an alternative stack if there isn't already one, or if the current
   // one is too small.


### PR DESCRIPTION
SIGSTKSZ is no longer a compile time constant in
glibc 2.34 and later.

Fix https://github.com/getsentry/sentry-native/issues/501