### PR TITLE
Remove third_party/lss

### DIFF
--- a/src/client/linux/crash_generation/crash_generation_client.cc
+++ b/src/client/linux/crash_generation/crash_generation_client.cc
@@ -40,7 +40,7 @@
 
 #include "common/linux/eintr_wrapper.h"
 #include "common/linux/ignore_ret.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace google_breakpad {
 

--- a/src/client/linux/handler/exception_handler.cc
+++ b/src/client/linux/handler/exception_handler.cc
@@ -98,7 +98,7 @@
 #include "client/linux/minidump_writer/linux_dumper.h"
 #include "client/linux/minidump_writer/minidump_writer.h"
 #include "common/linux/eintr_wrapper.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 #if defined(__ANDROID__)
 #include "linux/sched.h"

--- a/src/client/linux/handler/exception_handler_unittest.cc
+++ b/src/client/linux/handler/exception_handler_unittest.cc
@@ -53,7 +53,7 @@
 #include "common/linux/linux_libc_support.h"
 #include "common/tests/auto_tempdir.h"
 #include "common/using_std_string.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 #include "google_breakpad/processor/minidump.h"
 
 using namespace google_breakpad;

--- a/src/client/linux/log/log.cc
+++ b/src/client/linux/log/log.cc
@@ -36,7 +36,7 @@
 #include <android/log.h>
 #include <dlfcn.h>
 #else
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 #endif
 
 namespace logger {

--- a/src/client/linux/minidump_writer/cpu_set.h
+++ b/src/client/linux/minidump_writer/cpu_set.h
@@ -34,7 +34,7 @@
 #include <string.h>
 
 #include "common/linux/linux_libc_support.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace google_breakpad {
 

--- a/src/client/linux/minidump_writer/directory_reader.h
+++ b/src/client/linux/minidump_writer/directory_reader.h
@@ -37,7 +37,7 @@
 #include <string.h>
 
 #include "common/linux/linux_libc_support.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace google_breakpad {
 

--- a/src/client/linux/minidump_writer/line_reader.h
+++ b/src/client/linux/minidump_writer/line_reader.h
@@ -34,7 +34,7 @@
 #include <string.h>
 
 #include "common/linux/linux_libc_support.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace google_breakpad {
 

--- a/src/client/linux/minidump_writer/linux_dumper.cc
+++ b/src/client/linux/minidump_writer/linux_dumper.cc
@@ -54,7 +54,7 @@
 #include "common/linux/memory_mapped_file.h"
 #include "common/linux/safe_readlink.h"
 #include "google_breakpad/common/minidump_exception_linux.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 using google_breakpad::elf::FileID;
 

--- a/src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc
+++ b/src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc
@@ -42,7 +42,7 @@
 #include <unistd.h>
 
 #include "common/scoped_ptr.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 #if defined(__ARM_EABI__)
 #define TID_PTR_REGISTER "r3"

--- a/src/client/linux/minidump_writer/linux_ptrace_dumper.cc
+++ b/src/client/linux/minidump_writer/linux_ptrace_dumper.cc
@@ -60,7 +60,7 @@
 #include "client/linux/minidump_writer/directory_reader.h"
 #include "client/linux/minidump_writer/line_reader.h"
 #include "common/linux/linux_libc_support.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 // Suspends a thread by attaching to it.
 static bool SuspendThread(pid_t pid) {

--- a/src/client/linux/minidump_writer/minidump_writer.cc
+++ b/src/client/linux/minidump_writer/minidump_writer.cc
@@ -82,7 +82,7 @@
 #include "common/linux/linux_libc_support.h"
 #include "common/minidump_type_helper.h"
 #include "google_breakpad/common/minidump_format.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace {
 

--- a/src/client/linux/minidump_writer/proc_cpuinfo_reader.h
+++ b/src/client/linux/minidump_writer/proc_cpuinfo_reader.h
@@ -35,7 +35,7 @@
 
 #include "client/linux/minidump_writer/line_reader.h"
 #include "common/linux/linux_libc_support.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace google_breakpad {
 

--- a/src/client/minidump_file_writer.cc
+++ b/src/client/minidump_file_writer.cc
@@ -44,7 +44,7 @@
 #include "common/linux/linux_libc_support.h"
 #include "common/string_conversion.h"
 #if defined(__linux__) && __linux__
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 #endif
 
 #if defined(__ANDROID__)

--- a/src/common/linux/file_id.cc
+++ b/src/common/linux/file_id.cc
@@ -49,7 +49,7 @@
 #include "common/linux/linux_libc_support.h"
 #include "common/linux/memory_mapped_file.h"
 #include "common/using_std_string.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace google_breakpad {
 namespace elf {

--- a/src/common/linux/memory_mapped_file.cc
+++ b/src/common/linux/memory_mapped_file.cc
@@ -43,7 +43,7 @@
 #include <unistd.h>
 
 #include "common/memory_range.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace google_breakpad {
 

--- a/src/common/linux/safe_readlink.cc
+++ b/src/common/linux/safe_readlink.cc
@@ -35,7 +35,7 @@
 
 #include <stddef.h>
 
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace google_breakpad {
 

--- a/src/common/memory_allocator.h
+++ b/src/common/memory_allocator.h
@@ -46,7 +46,7 @@
 #define sys_munmap munmap
 #define MAP_ANONYMOUS MAP_ANON
 #else
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 #endif
 
 namespace google_breakpad {

--- a/src/processor/testdata/linux_test_app.cc
+++ b/src/processor/testdata/linux_test_app.cc
@@ -49,7 +49,7 @@
 #include <string>
 
 #include "client/linux/handler/exception_handler.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 
 namespace {
 

--- a/src/tools/linux/md2core/minidump-2-core.cc
+++ b/src/tools/linux/md2core/minidump-2-core.cc
@@ -55,7 +55,7 @@
 #include "common/using_std_string.h"
 #include "google_breakpad/common/breakpad_types.h"
 #include "google_breakpad/common/minidump_format.h"
-#include "third_party/lss/linux_syscall_support.h"
+#include "linux_syscall_support.h"
 #include "tools/linux/md2core/minidump_memory_range.h"
 
 #if ULONG_MAX == 0xffffffffffffffff


### PR DESCRIPTION
This pull request is a naive try to prevent patching sentry-breakpad in the conan-center-index as done here: https://github.com/conan-io/conan-center-index/blob/5b2024b2a/recipes/sentry-breakpad/all/conanfile.py#L82-L102
