### PR TITLE
feat: allow build to target Xbox Scarlett

### DIFF
--- a/src/client/windows/crash_generation/crash_generation_client.cc
+++ b/src/client/windows/crash_generation/crash_generation_client.cc
@@ -230,6 +230,9 @@ HANDLE CrashGenerationClient::ConnectToServer() {
 }
 
 bool CrashGenerationClient::RegisterClient(HANDLE pipe) {
+#ifdef _GAMING_XBOX_SCARLETT
+  return false;
+#else
   ProtocolMessage msg(MESSAGE_TAG_REGISTRATION_REQUEST,
                       GetCurrentProcessId(),
                       dump_type_,
@@ -271,6 +274,7 @@ bool CrashGenerationClient::RegisterClient(HANDLE pipe) {
   server_process_id_ = reply.id;
 
   return true;
+#endif // _GAMING_XBOX_SCARLETT
 }
 
 HANDLE CrashGenerationClient::ConnectToPipe(const wchar_t* pipe_name,


### PR DESCRIPTION
This is the only minor change necessary to target Xbox Scarlett from `breakpad`. We don't use client registration via pipes, so that code is irrelevant to our crash-reporting setup.