### PR TITLE
chore(readme): Add `README.getsentry.md` for Sentry modifications to Breakpad

### DIFF
--- a/README.getsentry.md
+++ b/README.getsentry.md
@@ -14,22 +14,6 @@ This is a fork of [Google Breakpad](https://chromium.googlesource.com/breakpad/b
 
 To minimize external dependencies and better integrate with `sentry-native`, this fork uses CMake instead of Breakpad's native Autotools/`configure` build system.
 
-The CMake build files are maintained in the parent `sentry-native` [repository](https://github.com/getsentry/sentry-native):
+The CMake build files are maintained in the parent [`sentry-native` repository](https://github.com/getsentry/sentry-native):
 
-- `../CMakeLists.txt` - Defines the `breakpad_client` target and lists all source files
-
-The source file list is derived from `breakpad/Makefile.am` but maintained manually in CMake format. When updating this fork, ensure the CMake file list stays in sync with any changes to the build configuration in upstream Breakpad.
-
-### Key Differences from Upstream Build
-
-- **No `configure` script**: The `./configure` file in this directory is unused. It's an artifact from upstream Breakpad.
-- **CMake only**: All builds use CMake with explicit source file lists
-- **C++17 required**: The CMake build enforces C++17 standard (set in `../CMakeLists.txt`)
-- **Client library only**: Only the client library (`breakpad_client`) is built, not the processor tools
-
-## How To Update
-
-1. Merge/rebase from upstream: `https://chromium.googlesource.com/breakpad/breakpad/`
-2. Check for changes in `Makefile.am` and update `../CMakeLists.txt` accordingly
-3. Review any new platform-specific code that might need adjustments for Xbox or modern glibc
-4. Test builds on all supported platforms (Windows, Linux, macOS, Xbox)
+- [`../../CMakeLists.txt`](https://github.com/getsentry/sentry-native/blob/master/CMakeLists.txt) - Defines the `breakpad_client` target and lists all source files

--- a/README.getsentry.md
+++ b/README.getsentry.md
@@ -8,13 +8,13 @@ This is a fork of [Google Breakpad](https://chromium.googlesource.com/breakpad/b
 - **Windows**: Xbox One build support
 - **Linux**: Cast `SIGSTKSZ` to int for compatibility with glibc 2.34+ (where it's no longer a compile-time constant)
 - **Build System**: CMake integration (see below)
-- **Minimum required C++17**
+- **C++17 standard requirement**: upstream uses C++20 (or newer).
 
 ## Build System Changes
 
 To minimize external dependencies and better integrate with `sentry-native`, this fork uses CMake instead of Breakpad's native Autotools/`configure` build system.
 
-The CMake build files are maintained in the parent `sentry-native` repository:
+The CMake build files are maintained in the parent `sentry-native` [repository](https://github.com/getsentry/sentry-native):
 
 - `../CMakeLists.txt` - Defines the `breakpad_client` target and lists all source files
 

--- a/README.getsentry.md
+++ b/README.getsentry.md
@@ -1,0 +1,35 @@
+# Sentry Modifications
+
+This is a fork of [Google Breakpad](https://chromium.googlesource.com/breakpad/breakpad/) maintained by Sentry for use in `sentry-native`.
+
+## Modifications
+
+- **Windows**: Dynamically size minidump paths instead of using `MAX_PATH` constant
+- **Windows**: Xbox One build support
+- **Linux**: Cast `SIGSTKSZ` to int for compatibility with glibc 2.34+ (where it's no longer a compile-time constant)
+- **Build System**: CMake integration (see below)
+- **Minimum required C++17**
+
+## Build System Changes
+
+To minimize external dependencies and better integrate with `sentry-native`, this fork uses CMake instead of Breakpad's native Autotools/`configure` build system.
+
+The CMake build files are maintained in the parent `sentry-native` repository:
+
+- `../CMakeLists.txt` - Defines the `breakpad_client` target and lists all source files
+
+The source file list is derived from `breakpad/Makefile.am` but maintained manually in CMake format. When updating this fork, ensure the CMake file list stays in sync with any changes to the build configuration in upstream Breakpad.
+
+### Key Differences from Upstream Build
+
+- **No `configure` script**: The `./configure` file in this directory is unused. It's an artifact from upstream Breakpad.
+- **CMake only**: All builds use CMake with explicit source file lists
+- **C++17 required**: The CMake build enforces C++17 standard (set in `../CMakeLists.txt`)
+- **Client library only**: Only the client library (`breakpad_client`) is built, not the processor tools
+
+## How To Update
+
+1. Merge/rebase from upstream: `https://chromium.googlesource.com/breakpad/breakpad/`
+2. Check for changes in `Makefile.am` and update `../CMakeLists.txt` accordingly
+3. Review any new platform-specific code that might need adjustments for Xbox or modern glibc
+4. Test builds on all supported platforms (Windows, Linux, macOS, Xbox)

--- a/README.getsentry.md
+++ b/README.getsentry.md
@@ -4,10 +4,11 @@ This is a fork of [Google Breakpad](https://chromium.googlesource.com/breakpad/b
 
 ## Modifications
 
-- **Windows**: Dynamically size minidump paths instead of using `MAX_PATH` constant
-- **Windows**: Xbox One build support
-- **Linux**: Cast `SIGSTKSZ` to int for compatibility with glibc 2.34+ (where it's no longer a compile-time constant)
-- **Build System**: CMake integration (see below)
+- **Windows**: Dynamically size minidump paths instead of using `MAX_PATH` constant.
+- **Windows**: Xbox One build support.
+- **Linux**: Cast `SIGSTKSZ` to int for compatibility with glibc 2.34+ (where it's no longer a compile-time constant).
+- **Build System**: CMake integration (see below).
+- **macOS**: Extend the handler callback with a user-context (containing register state of the crash site) for x86_64 and arm64.
 - **C++17 standard requirement**: upstream uses C++20 (or newer).
 
 ## Build System Changes

--- a/README.md
+++ b/README.md
@@ -80,3 +80,8 @@ dependent repos are up-to-date.
     click on it, then “Add reviewer”, and enter in the code reviewer. Depending
     on your settings, you may not see an email, but the reviewer has been
     notified with google-breakpad-dev@googlegroups.com always CC’d.
+
+## Sentry modifications
+
+See [README.getsentry.md](README.getsentry.md) for more information on the
+changes, and on maintaining the fork.


### PR DESCRIPTION
This README details the modifications made to the Google Breakpad fork maintained by Sentry, including build system changes and platform support.

Based on the Crashpad-Sentry-README https://github.com/getsentry/crashpad/blob/getsentry/README.getsentry.md

Todo
- [x] clean up README.getsentry.md
- [x] add link to README.getsentry.md in the normal readme