### PR TITLE
fix(mac): use arm64 thread state accessors on new Apple SDKs

### DIFF
--- a/src/client/mac/handler/minidump_generator.cc
+++ b/src/client/mac/handler/minidump_generator.cc
@@ -243,10 +243,17 @@ bool MinidumpGenerator::GetThreadContext(mach_port_t thread_id, breakpad_ucontex
   GetContextARM64(state, &arm64_ctx);
 
   std::copy_n(std::begin(arm64_ctx.iregs), std::size(context->uc_mcontext->__ss.__x), std::begin(context->uc_mcontext->__ss.__x));
+#if defined(__darwin_arm_thread_state64_set_fp) && defined(__darwin_arm_thread_state64_set_lr_fptr) && defined(__darwin_arm_thread_state64_set_sp) && defined(__darwin_arm_thread_state64_set_pc_fptr)
+  __darwin_arm_thread_state64_set_fp(context->uc_mcontext->__ss, arm64_ctx.iregs[MD_CONTEXT_ARM64_REG_FP]);
+  __darwin_arm_thread_state64_set_lr_fptr(context->uc_mcontext->__ss, reinterpret_cast<void *>(arm64_ctx.iregs[MD_CONTEXT_ARM64_REG_LR]));
+  __darwin_arm_thread_state64_set_sp(context->uc_mcontext->__ss, arm64_ctx.iregs[MD_CONTEXT_ARM64_REG_SP]);
+  __darwin_arm_thread_state64_set_pc_fptr(context->uc_mcontext->__ss, reinterpret_cast<void *>(arm64_ctx.iregs[MD_CONTEXT_ARM64_REG_PC]));
+#else
   context->uc_mcontext->__ss.__fp = arm64_ctx.iregs[MD_CONTEXT_ARM64_REG_FP];
   context->uc_mcontext->__ss.__lr = arm64_ctx.iregs[MD_CONTEXT_ARM64_REG_LR];
   context->uc_mcontext->__ss.__sp = arm64_ctx.iregs[MD_CONTEXT_ARM64_REG_SP];
   context->uc_mcontext->__ss.__pc = arm64_ctx.iregs[MD_CONTEXT_ARM64_REG_PC];
+#endif
   context->uc_mcontext->__ss.__cpsr = arm64_ctx.cpsr;
 #endif
   return true;


### PR DESCRIPTION
## Summary

Newer Apple SDKs expose `__darwin_arm_thread_state64` through accessor macros instead of allowing direct access to fields such as `__fp`, `__lr`, `__sp`, and `__pc`.

This change updates Breakpad's macOS arm64 context population code to prefer the official SDK accessors when available, while preserving the existing field-based code path for older SDKs.

## Problem

With newer Xcode / macOS SDKs, Breakpad fails to compile in `src/client/mac/handler/minidump_generator.cc` with errors like:

```txt
error: no member named '__fp' in '__darwin_arm_thread_state64'
```

This breaks downstream consumers that vendor Breakpad, including macOS arm64/arm64e builds.

## Fix

Use feature-based compatibility logic instead of SDK version checks:

- If the SDK provides:
  - __darwin_arm_thread_state64_set_fp
  - __darwin_arm_thread_state64_set_lr_fptr
  - __darwin_arm_thread_state64_set_sp
  - __darwin_arm_thread_state64_set_pc_fptr

  then use those official accessors.
- Otherwise, fall back to the existing direct field assignments for older SDKs.